### PR TITLE
Refactor training utilities and add CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,25 @@
+import typer
+import train
+
+app = typer.Typer()
+
+@app.command()
+def train_cli(
+    dataset_location: str = "fineweb10B",
+    epochs: int = 19073,
+    batch_size: int = 4,
+    block_size: int = 1024,
+    total_batch_size: int = 524288,
+    lr: float = 3e-4,
+):
+    train.train(
+        dataset_location=dataset_location,
+        epochs=epochs,
+        batch_size=batch_size,
+        block_size=block_size,
+        total_batch_size=total_batch_size,
+        lr=lr,
+    )
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
## Summary
- cleanup duplicated code and unused comments
- refactor `train.py` into a reusable `train()` function
- add Typer-based `cli.py` for command line training

## Testing
- `python -m py_compile train.py cli.py`

------
https://chatgpt.com/codex/tasks/task_e_685198dd824c832c9ff42cd2178a16ab